### PR TITLE
PHPCompat: remove PHP4-style constructor

### DIFF
--- a/opml-importer.php
+++ b/opml-importer.php
@@ -164,8 +164,6 @@ if ( ! $blogrolling )
 	} // end case 1
 } // end switch
 	}
-
-	function OPML_Import() {}
 }
 
 $opml_importer = new OPML_Import();


### PR DESCRIPTION
PHP 4-style constructors where the constructor function name mirrors the class name have been deprecated since PHP 7.0 and support has been removed since PHP 8.0, which means they are now silently ignored.

Considering the constructor is empty and is overloading an equally [empty constructor in the `WP_Importer` class](https://developer.wordpress.org/reference/classes/wp_importer/), I'm fixing this by removing the method.

This should not be considered a BC-break as calling the constructor directly on an instantiated object was never the intention of the code anyway and instantiating the object via `new OPML_Import()` will now fall through to the parent constructor, which equally does nothing anyway.

Refs:
* https://wiki.php.net/rfc/remove_php4_constructors