### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/opml-importer.php
+++ b/opml-importer.php
@@ -150,7 +150,7 @@ foreach ($categories as $category) {
 					$titles[$i] = '';
 				if ( 'http' == substr($titles[$i], 0, 4) )
 					$titles[$i] = '';
-				$link = array( 'link_url' => $urls[$i], 'link_name' => $wpdb->escape($names[$i]), 'link_category' => is_null($cat_id) ? null : array($cat_id), 'link_description' => $wpdb->escape($descriptions[$i]), 'link_owner' => $user_ID, 'link_rss' => $feeds[$i]);
+				$link = array( 'link_url' => $urls[$i], 'link_name' => esc_sql($names[$i]), 'link_category' => is_null($cat_id) ? null : array($cat_id), 'link_description' => esc_sql($descriptions[$i]), 'link_owner' => $user_ID, 'link_rss' => $feeds[$i]);
 				wp_insert_link($link);
 				echo sprintf('<p>'.__('Inserted <strong>%s</strong>', 'opml-importer').'</p>', $names[$i]);
 			}

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -10,6 +10,9 @@ Stable tag: 0.2
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
+// If a user want to import links we must enable the link manager
+add_filter( 'pre_option_link_manager_enabled', '__return_true' );
+
 if ( !defined('WP_LOAD_IMPORTERS') )
 	return;
 

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/opml-importer/
 Description: Import links in OPML format.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.2
-Stable tag: 0.2
+Version: 0.3
+Stable tag: 0.3
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -53,6 +53,11 @@ switch ($step) {
 ?>
 
 <div class="wrap">
+<?php
+	if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		screen_icon();
+	}
+?>
 <h2><?php _e('Import your blogroll from another system', 'opml-importer') ?> </h2>
 <form enctype="multipart/form-data" action="admin.php?import=opml" method="post" name="blogroll">
 <?php wp_nonce_field('import-bookmarks') ?>

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -144,24 +144,23 @@ foreach ($categories as $category) {
 			/** Load OPML Parser */
 			include_once( ABSPATH . 'wp-admin/link-parse-opml.php' );
 
-			$link_count = count($names);
+			$link_count    = count($names);
+			$link_inserted = 0;
 			for ( $i = 0; $i < $link_count; $i++ ) {
-				if ('Last' == substr($titles[$i], 0, 4))
-					$titles[$i] = '';
-				if ( 'http' == substr($titles[$i], 0, 4) )
-					$titles[$i] = '';
 				$link = array( 'link_url' => $urls[$i], 'link_name' => esc_sql($names[$i]), 'link_category' => is_null($cat_id) ? null : array($cat_id), 'link_description' => esc_sql($descriptions[$i]), 'link_owner' => $user_ID, 'link_rss' => $feeds[$i]);
-				wp_insert_link($link);
-				echo sprintf('<p>'.__('Inserted <strong>%s</strong>', 'opml-importer').'</p>', $names[$i]);
+				if ( wp_insert_link($link) !== 0 ) {
+					++$link_inserted;
+					echo sprintf('<p>'.__('Inserted <strong>%s</strong>', 'opml-importer').'</p>', $names[$i]);
+				}
 			}
 ?>
 
 <p>
 <?php
 	if ( is_null($cat_id) ) {
-		printf(__('Inserted %1$d links. All done! Go <a href="%2$s">manage those links</a>.', 'opml-importer'), $link_count, 'link-manager.php');
+		printf(__('Inserted %1$d links. All done! Go <a href="%2$s">manage those links</a>.', 'opml-importer'), $link_inserted, 'link-manager.php');
 	} else {
-		printf(__('Inserted %1$d links into category %2$s. All done! Go <a href="%3$s">manage those links</a>.', 'opml-importer'), $link_count, $cat_id, 'link-manager.php');
+		printf(__('Inserted %1$d links into category %2$s. All done! Go <a href="%3$s">manage those links</a>.', 'opml-importer'), $link_inserted, $cat_id, 'link-manager.php');
 	}
 ?>
 </p>

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -114,13 +114,9 @@ if ( is_wp_error( $categories ) ) { ?>
 
 <h2><?php _e('Importing...', 'opml-importer') ?></h2>
 <?php
-		$cat_id = null;
-		if( isset( $_POST['cat_id'] ) ) {
-			$cat_id = abs( (int) $_POST['cat_id'] );
-
-			if ( $cat_id < 1 ) {
-				$cat_id = 1;
-			}
+		$cat_id = isset( $_POST['cat_id'] ) ? abs( (int) $_POST['cat_id'] ) : 1;
+		if ( $cat_id < 1 ) {
+			$cat_id = 1;
 		}
 
 		$opml_url = $_POST['opml_url'];
@@ -156,7 +152,7 @@ if ( is_wp_error( $categories ) ) { ?>
 				$link = array(
 					'link_url'         => $urls[$i],
 					'link_name'        => $names[$i],
-					'link_category'    => is_null( $cat_id ) ? null : array($cat_id),
+					'link_category'    => array( $cat_id ),
 					'link_description' => $descriptions[$i],
 					'link_owner'       => $user_ID,
 					'link_rss'         => $feeds[$i],

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -50,7 +50,6 @@ switch ($step) {
 ?>
 
 <div class="wrap">
-<?php screen_icon(); ?>
 <h2><?php _e('Import your blogroll from another system', 'opml-importer') ?> </h2>
 <form enctype="multipart/form-data" action="admin.php?import=opml" method="post" name="blogroll">
 <?php wp_nonce_field('import-bookmarks') ?>

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -52,7 +52,7 @@ switch ($step) {
 
 <div class="wrap">
 <?php
-if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 	screen_icon();
 }
 ?>
@@ -192,7 +192,7 @@ if ( ! $blogrolling )
 	// Check if the Link Manager is enabled
 	function check_link_manager() {
 		// The Link Manager has been disabled in WordPress >= 3.5.0, no need to do additional checks
-		if ( version_compare(get_bloginfo('version'), '3.5.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			return;
 		}
 

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -73,15 +73,20 @@ switch ($step) {
 
 </div>
 
+<?php
+$categories = get_terms('link_category', array('get' => 'all'));
+
+if ( count($categories) ) {
+?>
 <p style="clear: both; margin-top: 1em;"><label for="cat_id"><?php _e('Now select a category you want to put these links in.', 'opml-importer') ?></label><br />
 <?php _e('Category:', 'opml-importer') ?> <select name="cat_id" id="cat_id">
 <?php
-$categories = get_terms('link_category', array('get' => 'all'));
 foreach ($categories as $category) {
 ?>
 <option value="<?php echo $category->term_id; ?>"><?php echo esc_html(apply_filters('link_category', $category->name)); ?></option>
 <?php
 } // end foreach
+} // end if
 ?>
 </select></p>
 
@@ -104,9 +109,13 @@ foreach ($categories as $category) {
 
 <h2><?php _e('Importing...', 'opml-importer') ?></h2>
 <?php
-		$cat_id = abs( (int) $_POST['cat_id'] );
-		if ( $cat_id < 1 )
-			$cat_id  = 1;
+		$cat_id = null;
+		if( array_key_exists( 'cat_id', $_POST ) ) {
+			$cat_id = abs( (int) $_POST['cat_id'] );
+
+			if ( $cat_id < 1 )
+				$cat_id  = 1;
+		}
 
 		$opml_url = $_POST['opml_url'];
 		if ( isset($opml_url) && $opml_url != '' && $opml_url != 'http://' ) {
@@ -141,14 +150,21 @@ foreach ($categories as $category) {
 					$titles[$i] = '';
 				if ( 'http' == substr($titles[$i], 0, 4) )
 					$titles[$i] = '';
-				$link = array( 'link_url' => $urls[$i], 'link_name' => $wpdb->escape($names[$i]), 'link_category' => array($cat_id), 'link_description' => $wpdb->escape($descriptions[$i]), 'link_owner' => $user_ID, 'link_rss' => $feeds[$i]);
+				$link = array( 'link_url' => $urls[$i], 'link_name' => $wpdb->escape($names[$i]), 'link_category' => is_null($cat_id) ? null : array($cat_id), 'link_description' => $wpdb->escape($descriptions[$i]), 'link_owner' => $user_ID, 'link_rss' => $feeds[$i]);
 				wp_insert_link($link);
 				echo sprintf('<p>'.__('Inserted <strong>%s</strong>', 'opml-importer').'</p>', $names[$i]);
 			}
 ?>
 
-<p><?php printf(__('Inserted %1$d links into category %2$s. All done! Go <a href="%3$s">manage those links</a>.', 'opml-importer'), $link_count, $cat_id, 'link-manager.php') ?></p>
-
+<p>
+<?php
+	if ( is_null($cat_id) ) {
+		printf(__('Inserted %1$d links. All done! Go <a href="%2$s">manage those links</a>.', 'opml-importer'), $link_count, 'link-manager.php');
+	} else {
+		printf(__('Inserted %1$d links into category %2$s. All done! Go <a href="%3$s">manage those links</a>.', 'opml-importer'), $link_count, $cat_id, 'link-manager.php');
+	}
+?>
+</p>
 <?php
 } // end if got url
 else

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Plugin Name ===
 Contributors: wordpressdotorg
-Donate link: 
+Donate link:
 Tags: importer, opml
 Requires at least: 3.0
-Tested up to: 4.1
-Stable tag: trunk
+Tested up to: 6.1
+Stable tag: 0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,13 @@ Import links in OPML format.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3 =
+* Add support for WordPress 6.1
+
+= 0.2 =
+* Add l18n
+* Update license
 
 = 0.1 =
 * Initial release


### PR DESCRIPTION
This PR upgrades the plugin to 0.3 and adds these fixes:

1. Tested with WordPress `6.1`
2. Tested with PHP `7.4.33`
3. Remove the deprecated `screen_icon` function for WordPress >= 3.8.0
4. Substitute deprecated `$wpdb->escape` function
5. Additional check on an empty list of categories
6. Additional check of the number of links inserted
7. Check if the link manager (needed by this plugin) is enabled for the WordPress > 3.5 installations where it is [hidden by default](https://wordpress.org/support/wordpress-version/version-3-5/#links). This mimics the behavior found in [wp_link_manager_disabled_message](https://developer.wordpress.org/reference/functions/wp_link_manager_disabled_message/).

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **OPML Importer**
5. Open `http://localhost/wp-admin/admin.php?import=opml`
6. It will ask you to enable the link manager if you don't have it
7. Import an OPML file
9. The plugin must load correctly, and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/opml-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
