### PR TITLE
Testing the plugin up to WordPress 6.2

### DIFF
--- a/languages/opml-importer.pot
+++ b/languages/opml-importer.pot
@@ -1,20 +1,20 @@
-# Translation of the WordPress plugin OPML Importer 0.3.1 by wordpressdotorg.
-# Copyright (C) 2010-2022 wordpressdotorg
+# Translation of the WordPress plugin OPML Importer 0.3.2 by wordpressdotorg.
+# Copyright (C) 2010-2023 wordpressdotorg
 # This file is distributed under the same license as the OPML Importer package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2010.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OPML Importer 0.3.1\n"
+"Project-Id-Version: OPML Importer 0.3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/opml-importer\n"
-"POT-Creation-Date: 2022-12-06T11:35:20+00:00\n"
-"PO-Revision-Date: 2022-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2023-04-07T11:23:13+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: opml-importer\n"
 

--- a/opml-importer.php
+++ b/opml-importer.php
@@ -5,8 +5,8 @@ Plugin URI: http://wordpress.org/extend/plugins/opml-importer/
 Description: Import links in OPML format.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.3.1
-Stable tag: 0.3.1
+Version: 0.3.2
+Stable tag: 0.3.2
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg
 Tags: importer, opml
 Requires at least: 3.0
-Tested up to: 6.1
-Stable tag: 0.3.1
+Tested up to: 6.2
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,10 @@ Import links in OPML format.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.3.2 =
+* Testing the plugin up to WordPress 6.2
+* Update translation
 
 = 0.3.1 =
 * Update translation


### PR DESCRIPTION
This PR adds support for WordPress 6.2 and upgrades the plugin to 0.3.2.

Tested with WordPress 6.2
Tested with PHP 5.6, PHP 7.4, PHP 8.0
How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "5.6",
  "plugins": ["./opml-importer"]
}
```
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=opml` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors