### PR TITLE
Test plugin for WordPress 6.4.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: importer, opml
 Requires at least: 3.0
-Tested up to: 6.3
+Tested up to: 6.4.2
 Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR updates the `Tested up to` label up to WordPress 6.4.2

Tested with WordPress 6.4.2
Tested with PHP 7.0, 7.4, 8.0
How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "7.0",
  "plugins": ["./opml-importer"]
}
```
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=opml` and perform an import.
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors