### PR TITLE
Update tested up to label

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: importer, opml
 Requires at least: 3.0
-Tested up to: 6.6.2
+Tested up to: 6.6
 Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: importer, opml
 Requires at least: 3.0
-Tested up to: 6.4.2
+Tested up to: 6.6.2
 Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.6.2.

Tested with WordPress 6.6.2
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is blogger-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./blogger-importer"]
}
```
Run `wp-env start` to spin up the WordPress.

Navigate to `http://localhost:8888/wp-admin/admin.php?import=opml`. WordPress will ask you to install the link plugin. Import the content from an XML; it can take a while if you have a lot of content. If the script timeout, you need to `set_time_limit` to a higher value
Check and see if the links have been imported in `wp-admin/link-manager.php` without errors and warnings.